### PR TITLE
Limit concurrent tasks to mitigate memory leaks

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -13,6 +13,7 @@ from threading import Timer
 from pathlib import Path
 from phue import Bridge
 import subprocess
+import contextlib
 import traceback
 import textwrap
 import requests


### PR DESCRIPTION
Potential issues related to too many concurrent processes or memory leaks.

e.g. After a while the display does not update with what is being spoken, indicating another process has control of the display