### PR TITLE
Update deprecated Spotify package to latest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
     update-alternatives --config python3 --force
 
 # Download and setup spotifyd binary from latest GitHub release
-RUN wget https://github.com/Spotifyd/spotifyd/releases/latest/download/spotifyd-linux-armhf-full.tar.gz && \
-    tar xzf spotifyd-linux-armhf-full.tar.gz -C /usr/local/bin && \
-    rm spotifyd-linux-armhf-full.tar.gz
+RUN wget https://github.com/Spotifyd/spotifyd/releases/latest/download/spotifyd-linux-armv7-full.tar.gz && \
+    tar xzf spotifyd-linux-armv7-full.tar.gz -C /usr/local/bin && \
+    rm spotifyd-linux-armv7-full.tar.gz
 
 # Create Spotifyd configuration (this is just a basic config; adjust accordingly)
 RUN mkdir -p /root/.config/spotifyd && { \


### PR DESCRIPTION
Tested manually that container now builds, however terminal shows  
`spotifyd                         FATAL     command at '/usr/local/bin/spotifyd' is not executable
`