### PR TITLE
Spotifyd version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
     update-alternatives --config python3 --force
 
 # Download and setup spotifyd binary from GitHub release version v0.4.1
-RUN curl -L https://github.com/Spotifyd/spotifyd/releases/v0.4.1/download/spotifyd-linux-aarch64-default.tar.gz -o spotifyd.tar.gz && \
+RUN curl -L https://github.com/Spotifyd/spotifyd/releases/download/v0.4.1/spotifyd-linux-aarch64-default.tar.gz -o spotifyd.tar.gz && \
     tar xzf spotifyd.tar.gz -C /usr/local/bin && \
     rm spotifyd.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # Download and setup spotifyd binary from GitHub release version v0.4.1
 RUN curl -L https://github.com/Spotifyd/spotifyd/releases/download/v0.4.1/spotifyd-linux-aarch64-default.tar.gz -o spotifyd.tar.gz && \
-    tar xzf spotifyd.tar.gz -C /usr/local/bin && \
+    tar xzf spotifyd.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/spotifyd && \
     rm spotifyd.tar.gz
 
 # Create Spotifyd configuration (this is just a basic config; adjust accordingly)

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ RUN /bin/bash -c "yes | add-apt-repository universe && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     update-alternatives --config python3 --force
 
-# Download and setup spotifyd binary from latest GitHub release
-RUN wget https://github.com/Spotifyd/spotifyd/releases/latest/download/spotifyd-linux-armv7-full.tar.gz && \
-    tar xzf spotifyd-linux-armv7-full.tar.gz -C /usr/local/bin && \
-    rm spotifyd-linux-armv7-full.tar.gz
+# Download and setup spotifyd binary from GitHub release version v0.4.1
+RUN curl -L https://github.com/Spotifyd/spotifyd/releases/v0.4.1/download/spotifyd-linux-aarch64-default.tar.gz -o spotifyd.tar.gz && \
+    tar xzf spotifyd.tar.gz -C /usr/local/bin && \
+    rm spotifyd.tar.gz
 
 # Create Spotifyd configuration (this is just a basic config; adjust accordingly)
 RUN mkdir -p /root/.config/spotifyd && { \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
     update-alternatives --config python3 --force
 
 # Download and setup spotifyd binary from latest GitHub release
-RUN wget https://github.com/Spotifyd/spotifyd/releases/latest/download/spotifyd-linux-armhf-full.tar.gz && \
-    tar xzf spotifyd-linux-armhf-full.tar.gz -C /usr/local/bin && \
-    rm spotifyd-linux-armhf-full.tar.gz
+RUN wget https://github.com/Spotifyd/spotifyd/releases/latest/download/spotifyd-linux-armv7-full.tar.gz && \
+    tar xzf spotifyd-linux-armv7-full.tar.gz -C /usr/local/bin && \
+    rm spotifyd-linux-armv7-full.tar.gz
 
 # Create Spotifyd configuration (this is just a basic config; adjust accordingly)
 RUN mkdir -p /root/.config/spotifyd && { \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
-    ca-certificates software-properties-common wget tar 
+    ca-certificates software-properties-common tar
 
 # Install ARMhf base libraries
 RUN dpkg --add-architecture armhf


### PR DESCRIPTION
This updates the Spotifyd binary URL in the Dockerfile to fix a broken link and improve compatibility with newer Raspberry Pi models.

* The previously used `spotifyd-linux-armhf-full.tar.gz` binary stopped resolving under the `latest` tag, causing the build to fail with a 404.
* This replaces it with a direct download for `spotifyd-linux-aarch64-default.tar.gz` from version `v0.4.1`, which is a better match for Raspberry Pi 3 and newer (64-bit ARMv8 CPUs, typically running 64-bit OSes).
* Pinning the version avoids future issues if the `latest` release changes or drops binaries again.

This should restore build stability and align the binary with modern Pi hardware and operating systems.