### PR TITLE
Change`true` to `"true"` for `sayHeard` setting

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -5,7 +5,7 @@
   "temperature": 0.7,
   "custom_instructions": "",
   "dark_mode": true,
-  "sayHeard": true,
+  "sayHeard": "true",
   "openai_api_key": "",
   "litellm_api_key": ""
 }


### PR DESCRIPTION
The `sayHeard` setting is meant to be a string, but is a boolean in the default settings.json. This change makes the value a string so the default will be used properly, and so it matches the type that the settings page changes it to.